### PR TITLE
remove secrets from compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 brew install podman podman-compose
 ```
 
+### Set required secrets
+```bash
+podman secret create sonar_jdbc_password /path/to/file/containing/secret
+podman secret create postgres_password /path/to/file/containing/secret
+```
+
 ### Run server
 ```bash
 podman compose up --detach

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,10 +4,13 @@ services:
     image: sonarqube:community
     depends_on:
       - db
+    secrets:
+      - source: sonar_jdbc_password
+        type: env
+        target: SONAR_JDBC_PASSWORD
     environment:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
-      SONAR_JDBC_PASSWORD: sonar
     volumes:
       - sonarqube_data:/opt/sonarqube/data
       - sonarqube_extensions:/opt/sonarqube/extensions
@@ -16,16 +19,23 @@ services:
       - "9000:9000"
   db:
     image: postgres:12
+    secrets:
+      - source: postgres_password
+        type: env
+        target: POSTGRES_PASSWORD
     environment:
       POSTGRES_USER: sonar
-      POSTGRES_PASSWORD: sonar
     volumes:
       - postgresql:/var/lib/postgresql
       - postgresql_data:/var/lib/postgresql/data
-
 volumes:
   sonarqube_data:
   sonarqube_extensions:
   sonarqube_logs:
   postgresql:
   postgresql_data:
+secrets:
+  sonar_jdbc_password:
+    external: true
+  postgres_password:
+    external: true


### PR DESCRIPTION
Remove hard-coded secrets from the compose file. Even though this isn't meant to run in production or anywhere other than a local development machine, it's better to be safe and follow best practices.

To test:

⚠️ WARNING: DESTRUCTIVE STEP ⚠️ 

To fully test, you should destroy your current local deployment:
```bash
podman compose down
podman volume prune --filter "name=sonarqube-local"
```

And then follow all the steps in the updated README in this commit.