### PR TITLE
add missing instructions for configuring podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 brew install podman podman-compose
 ```
 
+### Initialize podman
+```bash
+podman machine init
+podman machine start
+```
+
 ### Set required secrets
 ```bash
 podman secret create sonar_jdbc_password /path/to/file/containing/secret


### PR DESCRIPTION
Add instructions for initializing the podman machine (not required on all platforms, but the dependencies instructions assume MacOS, so I'm adding instructions for MacOS to this README); thank you to @shvangar for the catch.